### PR TITLE
moved plotly import to treadmill_app. fixing error

### DIFF
--- a/treadmillAnalysis.py
+++ b/treadmillAnalysis.py
@@ -1,14 +1,12 @@
 #20160307
 
-import plotly
-print 'plotly.__version__=', plotly.__version__  # version >1.9.4 required
 import plotly.graph_objs as go
 
 import pandas
 import numpy as np
 import os.path
 import glob
-import ntpath #this shuod get paths on windws?
+import ntpath #this should get paths on windows?
 
 class treadmillAnalysis():
 	def __init__(self):

--- a/treadmill_app.py
+++ b/treadmill_app.py
@@ -6,7 +6,8 @@ from flask import Flask, abort, render_template, send_file, request
 from flask.ext.socketio import SocketIO, emit
 from flaskext.markdown import Markdown
 
-import random # testing
+import plotly
+import random  # testing
 import os, time, random
 from datetime import datetime
 from threading import Thread


### PR DESCRIPTION
While trying to run treadmill_app.py, I was getting a large error traceback that seemed to be originating from plotly and involving too many calls to __init__. Moving the import plotly statement to the base treadmill_app.py file seems to fix this error.
plotly version = 1.12.12
on raspberry pi 
Linux 4.4.37-v7+
See image for exception traceback. 
![treadmill_app_error](https://cloud.githubusercontent.com/assets/17486858/21239720/5847d894-c2c5-11e6-9b1e-fa66b89e1740.jpg)
